### PR TITLE
Modify correct Node version range

### DIFF
--- a/docs/development-and-code/setup_alternatives/setting-up-the-platform-client/README.md
+++ b/docs/development-and-code/setup_alternatives/setting-up-the-platform-client/README.md
@@ -17,7 +17,7 @@ Pre-requisite: Install the platform API by following one of the API setup guides
 {% endcontent-ref %}
 
 {% hint style="warning" %}
-Pre-requisite: Install Node V10.x or higher (you might want to use NVM for this) before continuing.
+Pre-requisite: Install Node with a version >= 10.X but lower than 13  (you might want to use NVM for this) before continuing.
 {% endhint %}
 
 ### **Getting the platform-client code**


### PR DESCRIPTION
[Related to Issue #4390]
A prompt during the installation process recommends the node version to be between V10 and V13. Although on the website docs, it says "Install Node V10.x or higher".

This pull request makes the following changes:
- The pull request modifies the recommended node version in the documentation for setting up the platform client. The set-up doesn't execute successfully with some higher versions of Node . So, this PR would make the version requirement more specific. 

Test checklist:
- [ ] I certify that I ran my checklist

Ping @ushahidi/platform
